### PR TITLE
Fix: return falsey for non-string values

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,8 @@ class SimpleDBStore {
 
     debug('response:',res)
     const attribute = res.GetAttributesResult.Attribute
-    return attribute && attribute.Value
+    const value = attribute && attribute.Value
+    return typeof value === 'string' ? value : undefined
   }
 
   async put (key, value) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "resolved": "https://registry.npmjs.org/aws-lib/-/aws-lib-0.3.0.tgz",
       "integrity": "sha1-ITwEuzV6fGdkvAmfWMtjNqlX0Zg=",
       "requires": {
-        "sax": "0.1.5",
-        "underscore": "1.5.2",
-        "xml2js": "0.1.14"
+        "sax": "0.1.x",
+        "underscore": "~1.5.2",
+        "xml2js": "0.1.x"
       }
     },
     "combined-stream": {
@@ -24,7 +24,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "component-emitter": {
@@ -65,9 +65,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -105,7 +105,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "ms": {
@@ -128,13 +128,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "safe-buffer": {
@@ -152,7 +152,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "superagent": {
@@ -160,16 +160,16 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       }
     },
     "underscore": {
@@ -187,7 +187,7 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
       "integrity": "sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=",
       "requires": {
-        "sax": "0.1.5"
+        "sax": ">=0.1.1"
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/interledgerjs/moneyd/issues/46, strangely enough.

When an undefined value was written to simpledb, it would then be read out as an empty object (due to some strange chain of type coercion). This fix causes any non-string value to be read out as undefined. 